### PR TITLE
Use Variant Template String in 00-Level-X-Axis Macro

### DIFF
--- a/Configuration/macros/00-Level-X-Axis
+++ b/Configuration/macros/00-Level-X-Axis
@@ -2,7 +2,7 @@
 ;
 ;   Level the X gantry by ramming at lower motor current against the Z toppers
 ;
-;   for Caribou320- E3d Thermistor - PINDA2
+;   for #CARIBOU_VARIANT
 ;
 ; =========================================================================================================
 ;


### PR DESCRIPTION
While going through the generated files, I noticed that the `00-Level-X-Axis` macro was always annotated for the `Caribou320- E3d Thermistor - PINDA2`. I replaced the hard-coded string with the appropriate variant name variable to reduce confusion.

Feel free to close this PR if the proposed change does not seem helpful to you. 